### PR TITLE
Strip data on import

### DIFF
--- a/back/server/pm/logic/component_import.py
+++ b/back/server/pm/logic/component_import.py
@@ -33,12 +33,17 @@ def process_component(
     collection: Optional[str] = None,
     manufacturer: Optional[str] = None,
 ) -> None:
+    code, name = code.strip(), name.strip()
+    description = description and description.stip()
+    collection = collection and collection.strip()
+    manufacturer = manufacturer and manufacturer.strip()
+
     collection_instance = None
     if collection:
         collection_instance, _ = Collection.objects.get_or_create(name=collection)
 
     manufacturer_instance = None
-    if manufacturer: # было if collection
+    if manufacturer:
         manufacturer_instance, _ = Manufacturer.objects.get_or_create(name=manufacturer)
 
     component = Component.objects.filter(code=code, collection=collection_instance)


### PR DESCRIPTION
Поправил удаление лишних пробелов при импорте компонентов

Мне кажется что логичнее чистить данные в том месте, где они будут использоваться, а парсинг xlsx и csv оставить как есть

Чтобы почистить в базе нужно выполнить что-то вроде такого запроса

```
UPDATE pm_component SET code=TRIM(code);
```